### PR TITLE
Fixed the bug

### DIFF
--- a/rock-paper-scissors.py
+++ b/rock-paper-scissors.py
@@ -69,9 +69,9 @@ def play_game():
         print(winner)
 
         # This updates the scores
-        if winner.startswith("You win"):
+        if winner.startswith("\nYou win"):
             scores["user"] += 1
-        elif winner.startswith("You lose"):
+        elif winner.startswith("\nYou lose"):
             scores["computer"] += 1
         else:
             pass


### PR DESCRIPTION
Fixed a bug where the score was not updating. The issue was the method 'winner.startswith'. Since I changed the winning sentences in another function from 'You win,' and 'You lose,' to '\nYou win,' and '\nYou lose,' the method was not working correctly and skipping to the else statement. Fixed it by adding the text to include the '\n'.